### PR TITLE
ALVA-906 Support additional properties in codegen config to add dependencies.

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
@@ -34,6 +34,9 @@ public class CodegenConstants {
     public static final String LOCAL_VARIABLE_PREFIX = "localVariablePrefix";
     public static final String LOCAL_VARIABLE_PREFIX_DESC = "prefix for generated code members and local variables";
 
+    public static final String DEPENDENCIES = "dependencies";
+    public static final String DEPENDENCIES_DESC = "declare a list of used dependencies";
+
     public static final String SERIALIZABLE_MODEL = "serializableModel";
     public static final String SERIALIZABLE_MODEL_DESC = "boolean - toggle \"implements Serializable\" for generated models";
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfigurator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfigurator.java
@@ -467,8 +467,6 @@ public class CodegenConfigurator {
     }
 
     private void checkAndSetAdditionalProperty(Object property, Object valueToSet, String propertyKey) {
-        Validate.notNull(property);
-
         if (property instanceof String) {
             if (isNotEmpty((String) property)) {
                 additionalProperties.put(propertyKey, valueToSet);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfigurator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfigurator.java
@@ -2,6 +2,7 @@ package io.swagger.codegen.config;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.codegen.CliOption;
 import io.swagger.codegen.ClientOptInput;
 import io.swagger.codegen.ClientOpts;
@@ -466,12 +467,16 @@ public class CodegenConfigurator {
     }
 
     private void checkAndSetAdditionalProperty(Object property, Object valueToSet, String propertyKey) {
+        Validate.notNull(property);
+
         if (property instanceof String) {
             if (isNotEmpty((String) property)) {
                 additionalProperties.put(propertyKey, valueToSet);
             }
         } else if (property instanceof List) {
-            if (null != property) {
+            List list = (List) property;
+
+            if (!list.isEmpty()) {
                 additionalProperties.put(propertyKey, valueToSet);
             }
         }
@@ -481,11 +486,14 @@ public class CodegenConfigurator {
 
         if (isNotEmpty(configFile)) {
             try {
+                ObjectMapper mapper = new ObjectMapper();
                 if (configFile.endsWith(".json")) {
-                    return Json.mapper().readValue(new File(configFile), CodegenConfigurator.class);
+                    mapper = Json.mapper();
                 } else if (configFile.endsWith(".yaml")) {
-                    return Yaml.mapper().readValue(new File(configFile), CodegenConfigurator.class);
+                    mapper = Yaml.mapper();
                 }
+
+                return mapper.readValue(new File(configFile), CodegenConfigurator.class);
             } catch (IOException e) {
                 LOGGER.error("Unable to deserialize config file: " + configFile, e);
             }

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/libraries/jersey1/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/libraries/jersey1/pom.mustache
@@ -84,6 +84,14 @@
     </plugins>
   </build>
   <dependencies>
+    {{#dependencies}}
+    <dependency>
+      <groupId>{{groupId}}</groupId>
+      <artifactId>{{artifactId}}</artifactId>
+      <scope>{{scope}}</scope>
+      <version>{{version}}</version>
+    </dependency>
+    {{/dependencies}}
     <dependency>
       <groupId>io.swagger</groupId>
       <artifactId>swagger-jersey-jaxrs</artifactId>

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/libraries/jersey1/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/libraries/jersey1/pom.mustache
@@ -88,7 +88,9 @@
     <dependency>
       <groupId>{{groupId}}</groupId>
       <artifactId>{{artifactId}}</artifactId>
+      {{#classifier}}
       <classifier>{{classifier}}</classifier>
+      {{/classifier}}
       <scope>{{scope}}</scope>
       <version>{{version}}</version>
     </dependency>

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/libraries/jersey1/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/libraries/jersey1/pom.mustache
@@ -88,6 +88,7 @@
     <dependency>
       <groupId>{{groupId}}</groupId>
       <artifactId>{{artifactId}}</artifactId>
+      <classifier>{{classifier}}</classifier>
       <scope>{{scope}}</scope>
       <version>{{version}}</version>
     </dependency>

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/config/CodegenConfiguratorTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/config/CodegenConfiguratorTest.java
@@ -1,5 +1,7 @@
 package io.swagger.codegen.config;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.swagger.codegen.ClientOptInput;
 import io.swagger.codegen.CodegenConfig;
 import io.swagger.codegen.CodegenConfigLoader;
@@ -249,44 +251,52 @@ public class CodegenConfiguratorTest {
 
     @Test
     public void testFromFile() throws Exception {
-        final CodegenConfigurator configurator = CodegenConfigurator.fromFile("src/test/resources/sampleConfig.json");
+        List<String> files = ImmutableList.of("src/test/resources/sampleConfig.json",
+                "src/test/resources/sampleConfig.yaml");
 
-        assertEquals(configurator.getLang(), "java");
-        assertEquals(configurator.getInputSpec(), "swagger.yaml");
-        assertEquals(configurator.getOutputDir(), toAbsolutePathDir("src/gen/java"));
-        assertEquals(configurator.isVerbose(), true);
-        assertEquals(configurator.isSkipOverwrite(), true);
-        assertEquals(configurator.getTemplateDir(), toAbsolutePathDir("src/main/resources"));
-        assertEquals(configurator.getAuth(), "hello:world");
-        assertEquals(configurator.getApiPackage(), "io.something.api");
-        assertEquals(configurator.getModelPackage(), "io.something.models");
-        assertEquals(configurator.getInvokerPackage(), "io.something.invoker");
-        assertEquals(configurator.getGroupId(), "io.something");
-        assertEquals(configurator.getArtifactId(), "awesome-api");
-        assertEquals(configurator.getArtifactVersion(), "1.2.3");
-        assertEquals(configurator.getLibrary(), "jersey2");
+        for (String file: files) {
+            final CodegenConfigurator configurator = CodegenConfigurator.fromFile(file);
 
-        assertEquals(configurator.getSystemProperties().size(), 1);
-        assertValueInMap(configurator.getSystemProperties(), "systemProp1", "value1");
+            assertEquals(configurator.getLang(), "java");
+            assertEquals(configurator.getInputSpec(), "swagger.yaml");
+            assertEquals(configurator.getOutputDir(), toAbsolutePathDir("src/gen/java"));
+            assertEquals(configurator.isVerbose(), true);
+            assertEquals(configurator.isSkipOverwrite(), true);
+            assertEquals(configurator.getTemplateDir(), toAbsolutePathDir("src/main/resources"));
+            assertEquals(configurator.getAuth(), "hello:world");
+            assertEquals(configurator.getApiPackage(), "io.something.api");
+            assertEquals(configurator.getModelPackage(), "io.something.models");
+            assertEquals(configurator.getInvokerPackage(), "io.something.invoker");
+            assertEquals(configurator.getGroupId(), "io.something");
+            assertEquals(configurator.getArtifactId(), "awesome-api");
+            assertEquals(configurator.getArtifactVersion(), "1.2.3");
+            assertEquals(configurator.getLibrary(), "jersey2");
+            assertEquals(configurator.getDependencies(), ImmutableList.of(ImmutableMap.of("property1", "A", "property2", "A1"),
+                    ImmutableMap.of("property1", "B", "property2", "B1")));
 
-        assertEquals(configurator.getInstantiationTypes().size(), 1);
-        assertValueInMap(configurator.getInstantiationTypes(), "hello", "world");
+            assertEquals(configurator.getSystemProperties().size(), 1);
+            assertValueInMap(configurator.getSystemProperties(), "systemProp1", "value1");
 
-        assertEquals(configurator.getTypeMappings().size(), 1);
-        assertValueInMap(configurator.getTypeMappings(), "foo", "bar");
+            assertEquals(configurator.getInstantiationTypes().size(), 1);
+            assertValueInMap(configurator.getInstantiationTypes(), "hello", "world");
 
-        assertEquals(configurator.getAdditionalProperties().size(), 1);
-        assertValueInMap(configurator.getAdditionalProperties(), "addtProp1", "value2");
+            assertEquals(configurator.getTypeMappings().size(), 1);
+            assertValueInMap(configurator.getTypeMappings(), "foo", "bar");
 
-        assertEquals(configurator.getImportMappings().size(), 1);
-        assertValueInMap(configurator.getImportMappings(), "type1", "import1");
+            assertEquals(configurator.getAdditionalProperties().size(), 1);
+            assertValueInMap(configurator.getAdditionalProperties(), "addtProp1", "value2");
+
+            assertEquals(configurator.getImportMappings().size(), 1);
+            assertValueInMap(configurator.getImportMappings(), "type1", "import1");
 
 
-        assertEquals(configurator.getLanguageSpecificPrimitives().size(), 1);
-        assertTrue(configurator.getLanguageSpecificPrimitives().contains("rolex"));
+            assertEquals(configurator.getLanguageSpecificPrimitives().size(), 1);
+            assertTrue(configurator.getLanguageSpecificPrimitives().contains("rolex"));
 
-        assertEquals(configurator.getDynamicProperties().size(), 1);
-        assertValueInMap(configurator.getDynamicProperties(), CodegenConstants.LOCAL_VARIABLE_PREFIX, "_");
+            assertEquals(configurator.getDynamicProperties().size(), 1);
+            assertValueInMap(configurator.getDynamicProperties(), CodegenConstants.LOCAL_VARIABLE_PREFIX, "_");
+        }
+
     }
 
     @SuppressWarnings("unused")

--- a/modules/swagger-codegen/src/test/resources/sampleConfig.json
+++ b/modules/swagger-codegen/src/test/resources/sampleConfig.json
@@ -29,5 +29,11 @@
         "type1" : "import1"
     },
     "languageSpecificPrimitives" : [ "rolex" ],
-    "localVariablePrefix" : "_"
+    "localVariablePrefix" : "_",
+    "dependencies" : [
+        {"property1" : "A",
+        "property2" : "A1"},
+        {"property1" : "B",
+        "property2" : "B1"}
+    ]
 }

--- a/modules/swagger-codegen/src/test/resources/sampleConfig.yaml
+++ b/modules/swagger-codegen/src/test/resources/sampleConfig.yaml
@@ -1,0 +1,32 @@
+lang: java
+inputSpec: swagger.yaml
+outputDir: src/gen/java
+verbose: true
+skipOverwrite: true
+templateDir: src/main/resources
+auth: hello:world
+apiPackage: io.something.api
+modelPackage: io.something.models
+invokerPackage: io.something.invoker
+groupId: io.something
+artifactId: awesome-api
+artifactVersion: 1.2.3
+library: jersey2
+systemProperties:
+    systemProp1: value1
+instantiationTypes:
+    hello: world
+typeMappings:
+    foo: bar
+additionalProperties:
+    addtProp1: value2
+importMappings:
+    type1: import1
+languageSpecificPrimitives:
+    - rolex
+localVariablePrefix: _
+dependencies:
+    - property1: A
+      property2: A1
+    - property1: B
+      property2: B1


### PR DESCRIPTION
Changes to make [swagger-codegen](https://github.com/swagger-api/swagger-codegen) more customizable, allowing an additional "dependencies" property to be added as external config from either a yaml or a json document. 
